### PR TITLE
necessary infrastructure for simulation of carfree areas

### DIFF
--- a/src/main/java/org/matsim/analysis/BikeRouteAnalysis.java
+++ b/src/main/java/org/matsim/analysis/BikeRouteAnalysis.java
@@ -1,0 +1,96 @@
+package org.matsim.analysis;
+
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.population.*;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.utils.gis.ShapeFileReader;
+import org.matsim.core.utils.io.IOUtils;
+import org.opengis.feature.simple.SimpleFeature;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BikeRouteAnalysis {
+    static Geometry consideredArea = null;
+    Map<Id<Person>, List<PlanElement>> consideredPersonsWithCar = new HashMap<>();
+    Map<Id<Person>, List<PlanElement>> consideredPersonsCarless = new HashMap<>();
+
+    public static void main ( String [] args ) {
+
+        String inputPopWithCar = "C:/Users/Simon/Documents/VSP-Projects/matsim-leipzig/output/it-1pct/ITERS/it.0/leipzig-25pct.0.plans.xml.gz";
+        String inputPopCarless = "C:/Users/Simon/Documents/VSP-Projects/matsim-leipzig/output/it-1pct_carFree/ITERS/it.0/leipzig-25pct.0.plans.xml.gz";
+        String consideredAreaShpFile = "C:/Users/Simon/Documents/shared-svn/projects/NaMAV/data/carFree-scenario/Leipzig_autofreie_Zonen_utm32n/Leipzig_autofreie_Zonen_Innenstadt_utm32n.shp";
+        String outputFile = "C:/Users/Simon/Desktop/bikeLegsOnlyComparison.csv";
+
+        ShapeFileReader shpReader = new ShapeFileReader();
+        Collection<SimpleFeature> features = shpReader.readFileAndInitialize(consideredAreaShpFile);
+
+        for(SimpleFeature feature : features) {
+            if(consideredArea == null) {
+                consideredArea = (Geometry) feature.getDefaultGeometry();
+            } else {
+                consideredArea = consideredArea.union((Geometry) feature.getDefaultGeometry());
+            }
+        }
+
+        Population popWithCar = PopulationUtils.readPopulation(inputPopWithCar);
+        Population popCarless = PopulationUtils.readPopulation(inputPopCarless);
+
+        BikeRouteAnalysis bikeRouteAnalysis = new BikeRouteAnalysis();
+        bikeRouteAnalysis.analyzeBikeRoutes(popWithCar, popCarless);
+        bikeRouteAnalysis.writeData(outputFile);
+    }
+
+    void analyzeBikeRoutes(Population pop1, Population pop2) {
+        for ( Person person : pop1.getPersons().values() ) {
+            Plan selectedPlan = person.getSelectedPlan() ;
+
+            for(PlanElement element : selectedPlan.getPlanElements()) {
+                if(!(element instanceof Activity)) {
+                    continue;
+                }
+                if(!((Activity) element).getType().equals("bike interaction")) {
+                    continue;
+                }
+                if(MGC.coord2Point(((Activity) element).getCoord()).within(consideredArea)) {
+                    this.consideredPersonsWithCar.put(person.getId(), selectedPlan.getPlanElements());
+                }
+            }
+        }
+
+        for(Id<Person> personId : consideredPersonsWithCar.keySet()) {
+            consideredPersonsCarless.put(pop2.getPersons().get(personId).getId(),
+                    pop2.getPersons().get(personId).getSelectedPlan().getPlanElements());
+        }
+    }
+
+    void writeData(String outputFile) {
+        BufferedWriter writer = IOUtils.getBufferedWriter(outputFile);
+        try {
+            writer.write("PersonID;PlanElementWithCar;PlanElementCarless");
+            writer.newLine();
+
+            for (Id<Person> personId  : this.consideredPersonsWithCar.keySet()) {
+                for(PlanElement p : this.consideredPersonsWithCar.get(personId)) {
+                    if(p instanceof Leg) {
+                        if(((Leg) p).getMode().equals(TransportMode.bike)) {
+                            writer.write(personId + ";" + p + ";" +
+                                    this.consideredPersonsCarless.get(personId).get(this.consideredPersonsWithCar.get(personId).indexOf(p)));
+                            writer.newLine();
+                        }
+                    }
+                }
+            }
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/matsim/analysis/LeipzigModeStatsControlerListener.java
+++ b/src/main/java/org/matsim/analysis/LeipzigModeStatsControlerListener.java
@@ -1,0 +1,373 @@
+package org.matsim.analysis;
+
+import java.awt.*;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.inject.Inject;
+
+import org.apache.log4j.Logger;
+import org.jfree.chart.ChartUtils;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.xy.XYDataset;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.population.*;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.StartupEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.StartupListener;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.router.MainModeIdentifier;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.router.TripStructureUtils.Trip;
+import org.matsim.core.utils.charts.StackedBarChart;
+import org.matsim.core.utils.charts.XYLineChart;
+import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.utils.gis.ShapeFileReader;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.core.utils.io.UncheckedIOException;
+import org.opengis.feature.simple.SimpleFeature;
+
+
+/**
+ * Calculates at the end of each iteration mode statistics, based on the main mode identifier of a trip chain.
+ * For multi-modal trips, this is only as accurate as your main mode identifier.
+ * The calculated values are written to a file, each iteration on
+ * a separate line.
+ *
+ * @author mrieser
+ */
+public final class LeipzigModeStatsControlerListener implements StartupListener, IterationEndsListener {
+
+    public static final String FILENAME_MODESTATS = "modestats";
+
+    final private Population population;
+
+    final private String modeFileName ;
+
+    private final boolean createPNG;
+    private final ControlerConfigGroup controlerConfigGroup;
+
+    Map<String,Map<Integer,Double>> modeHistories = new HashMap<>() ;
+    Map<String,Map<Integer,Double>> carfreeAreaModeHistories = new HashMap<>() ;
+    private int minIteration = 0;
+    private MainModeIdentifier mainModeIdentifier;
+    private Map<String,Double> modeCnt = new TreeMap<>() ;
+    private Map<String,Double> carfreeAreaModeCnt = new TreeMap<>() ;
+    private int firstIteration = -1;
+
+    // Keep all modes encountered so far in a sorted set to ensure output is written for modes sorted by mode.
+    private final Set<String> modes = new TreeSet<>();
+
+    private final static Logger log = Logger.getLogger(LeipzigModeStatsControlerListener.class);
+
+    private String carfreeAreaShpFile = "C:/Users/Simon/Documents/shared-svn/projects/NaMAV/data/carFree-scenario/Leipzig_autofreie_Zonen_utm32n/Leipzig_autofreie_Zonen_Innenstadt_utm32n.shp";
+    private ShapeFileReader shpReader = new ShapeFileReader();
+    private Collection<SimpleFeature> features = shpReader.readFileAndInitialize(carfreeAreaShpFile);
+    private static Geometry carfreeAreaShape = null;
+
+
+    @Inject
+    LeipzigModeStatsControlerListener(ControlerConfigGroup controlerConfigGroup, Population population1, OutputDirectoryHierarchy controlerIO,
+                                      PlanCalcScoreConfigGroup scoreConfig, AnalysisMainModeIdentifier mainModeIdentifier) {
+        this.controlerConfigGroup = controlerConfigGroup;
+        this.population = population1;
+        this.modeFileName = controlerIO.getOutputFilename( FILENAME_MODESTATS ) ;
+        this.createPNG = controlerConfigGroup.isCreateGraphs();
+        this.mainModeIdentifier = mainModeIdentifier;
+    }
+
+    @Override
+    public void notifyStartup(final StartupEvent event) {
+        this.minIteration = controlerConfigGroup.getFirstIteration();
+    }
+
+    @Override
+    public void notifyIterationEnds(final IterationEndsEvent event) {
+
+        collectModeShareInfo(event) ;
+        collectCarfreeAreaModeShareInfo(event, extractCarfreeAreaPopulation()) ;
+    }
+
+    private Population extractCarfreeAreaPopulation() {
+
+        for(SimpleFeature feature : this.features) {
+            if(carfreeAreaShape == null) {
+                carfreeAreaShape = (Geometry) feature.getDefaultGeometry();
+            } else {
+                carfreeAreaShape = carfreeAreaShape.union((Geometry) feature.getDefaultGeometry());
+            }
+        }
+
+        Config config = ConfigUtils.createConfig();
+        Population carfreeAreaPop = PopulationUtils.createPopulation(config);
+
+        for(Person person : this.population.getPersons().values()) {
+
+            for(PlanElement pe : person.getSelectedPlan().getPlanElements()) {
+                if(pe instanceof Activity) {
+                    if(MGC.coord2Point(((Activity) pe).getCoord()).within(carfreeAreaShape)) {
+                        carfreeAreaPop.addPerson(person);
+                        break;
+                    }
+                }
+            }
+        }
+        return carfreeAreaPop;
+    }
+
+    private void collectCarfreeAreaModeShareInfo (final IterationEndsEvent event, Population carfreeAreaPop) {
+        if (firstIteration < 0) {
+            firstIteration = event.getIteration();
+        }
+
+        for(Person person : carfreeAreaPop.getPersons().values()) {
+            Plan plan = person.getSelectedPlan();
+            List<Trip> trips = TripStructureUtils.getTrips(plan);
+            for (Trip trip : trips) {
+                String mode = this.mainModeIdentifier.identifyMainMode(trip.getTripElements());
+                // yy as stated elsewhere, the "computer science" mode identification may not be the same as the "transport planning"
+                // mode identification.  Maybe revise.  kai, nov'16
+
+                Double cnt = this.carfreeAreaModeCnt.get( mode );
+                if ( cnt==null ) {
+                    cnt = 0. ;
+                }
+                this.carfreeAreaModeCnt.put( mode, cnt + 1 ) ;
+            }
+        }
+
+        double sum = 0 ;
+        for ( Double val : this.carfreeAreaModeCnt.values() ) {
+            sum += val ;
+        }
+
+        // add new modes not encountered in previous iterations
+        this.modes.addAll(carfreeAreaModeCnt.keySet());
+
+        // calculate and save this iteration's mode shares
+        log.info("Mode shares in carfree area over all " + sum + " trips found. MainModeIdentifier: " + mainModeIdentifier.getClass());
+        for ( String mode : modes ) {
+            Double cnt = this.carfreeAreaModeCnt.getOrDefault(mode, 0.0) ;
+            double share = 0. ;
+            if ( cnt!=null ) {
+                share = cnt/sum;
+            }
+            log.info("-- mode share in carfree area of mode " + mode + " = " + share );
+
+            Map<Integer, Double> modeHistory = this.carfreeAreaModeHistories.get(mode) ;
+            if ( modeHistory == null ) {
+                modeHistory = new TreeMap<>() ;
+                for (int iter = firstIteration; iter < event.getIteration(); iter++) {
+                    modeHistory.put(iter, 0.0);
+                }
+                this.carfreeAreaModeHistories.put(mode, modeHistory) ;
+            }
+            modeHistory.put( event.getIteration(), share ) ;
+        }
+
+        BufferedWriter modeOut = IOUtils.getBufferedWriter(this.modeFileName + "_carfreeArea" + ".txt");
+        try {
+            modeOut.write("Iteration");
+            for ( String mode : modes ) {
+                modeOut.write("\t" + mode);
+            }
+            modeOut.write("\n");
+            for (int iter = firstIteration; iter <= event.getIteration(); iter++) {
+                modeOut.write( String.valueOf(iter) ) ;
+                for ( String mode : modes ) {
+                    modeOut.write( "\t" + carfreeAreaModeHistories.get(mode).get(iter)) ;
+                }
+                modeOut.write( "\n" ) ;
+            }
+            modeOut.flush();
+            modeOut.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new UncheckedIOException(e);
+        }
+
+        // yyyy the following does not work!!
+        // Why? The charts seem to be useful (JB, April 2017)
+        if (this.createPNG && event.getIteration() > this.minIteration) {
+            // create chart when data of more than one iteration is available.
+            XYLineChart chart = new XYLineChart("Mode Statistics", "iteration", "mode");
+            for ( Entry<String, Map<Integer, Double>> entry : this.carfreeAreaModeHistories.entrySet() ) {
+                String mode = entry.getKey() ;
+                Map<Integer, Double> history = entry.getValue() ;
+//				log.warn( "about to add the following series:" ) ;
+//				for ( Entry<Integer, Double> item : history.entrySet() ) {
+//					log.warn( item.getKey() + " -- " + item.getValue() );
+//				}
+                chart.addSeries(mode, history ) ;
+            }
+            chart.addMatsimLogo();
+            chart.saveAsPng(this.modeFileName + "_carfreeArea" + ".png", 800, 600);
+
+            /////// EDIT: STACKED_BAR ///////////////////////////////////////////////////////
+            if (event.getIteration() > this.minIteration) {
+                // create chart when data of more than one iteration is available.
+                StackedBarChart chart2 = new StackedBarChart("Mode Statistics", "iteration", "share");
+                for (Entry<String, Map<Integer, Double>> entry : this.carfreeAreaModeHistories.entrySet()) {
+                    String mode = entry.getKey();
+                    Map<Integer, Double> history = entry.getValue();
+                    double[] historyArray = new double[history.size()];
+                    int i = 0;
+                    for ( Entry<Integer,Double> entryHistory : history.entrySet() ) {
+                        historyArray[i] = entryHistory.getValue();
+                        i++;
+                    }
+                    chart2.addSeries(mode, historyArray);
+                }
+                chart2.addMatsimLogo();
+                chart2.saveAsPng(this.modeFileName + "_carfreeArea" + "_stackedbar.png", 800, 600);
+            }
+        }
+        carfreeAreaModeCnt.clear();
+
+    }
+
+    //################################################################################################################################
+
+    private void collectModeShareInfo(final IterationEndsEvent event) {
+        if (firstIteration < 0) {
+            firstIteration = event.getIteration();
+        }
+        for (Person person : this.population.getPersons().values()) {
+            Plan plan = person.getSelectedPlan() ;
+            List<Trip> trips = TripStructureUtils.getTrips(plan) ;
+            for ( Trip trip : trips ) {
+                String mode = this.mainModeIdentifier.identifyMainMode( trip.getTripElements() ) ;
+                // yy as stated elsewhere, the "computer science" mode identification may not be the same as the "transport planning"
+                // mode identification.  Maybe revise.  kai, nov'16
+
+                Double cnt = this.modeCnt.get( mode );
+                if ( cnt==null ) {
+                    cnt = 0. ;
+                }
+                this.modeCnt.put( mode, cnt + 1 ) ;
+            }
+        }
+
+        double sum = 0 ;
+        for ( Double val : this.modeCnt.values() ) {
+            sum += val ;
+        }
+
+        // add new modes not encountered in previous iterations
+        this.modes.addAll(modeCnt.keySet());
+
+        // calculate and save this iteration's mode shares
+        log.info("Mode shares over all " + sum + " trips found. MainModeIdentifier: " + mainModeIdentifier.getClass());
+        for ( String mode : modes ) {
+            Double cnt = this.modeCnt.getOrDefault(mode, 0.0) ;
+            double share = 0. ;
+            if ( cnt!=null ) {
+                share = cnt/sum;
+            }
+            log.info("-- mode share of mode " + mode + " = " + share );
+
+            Map<Integer, Double> modeHistory = this.modeHistories.get(mode) ;
+            if ( modeHistory == null ) {
+                modeHistory = new TreeMap<>() ;
+                for (int iter = firstIteration; iter < event.getIteration(); iter++) {
+                    modeHistory.put(iter, 0.0);
+                }
+                this.modeHistories.put(mode, modeHistory) ;
+            }
+            modeHistory.put( event.getIteration(), share ) ;
+        }
+
+        BufferedWriter modeOut = IOUtils.getBufferedWriter(this.modeFileName + ".txt");
+        try {
+            modeOut.write("Iteration");
+            for ( String mode : modes ) {
+                modeOut.write("\t" + mode);
+            }
+            modeOut.write("\n");
+            for (int iter = firstIteration; iter <= event.getIteration(); iter++) {
+                modeOut.write( String.valueOf(iter) ) ;
+                for ( String mode : modes ) {
+                    modeOut.write( "\t" + modeHistories.get(mode).get(iter)) ;
+                }
+                modeOut.write( "\n" ) ;
+            }
+            modeOut.flush();
+            modeOut.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new UncheckedIOException(e);
+        }
+
+
+        // yyyy the following does not work!!
+        // Why? The charts seem to be useful (JB, April 2017)
+        if (this.createPNG && event.getIteration() > this.minIteration) {
+            // create chart when data of more than one iteration is available.
+            XYLineChart chart = new XYLineChart("Mode Statistics", "iteration", "mode");
+            for ( Entry<String, Map<Integer, Double>> entry : this.modeHistories.entrySet() ) {
+                String mode = entry.getKey() ;
+                Map<Integer, Double> history = entry.getValue() ;
+//				log.warn( "about to add the following series:" ) ;
+//				for ( Entry<Integer, Double> item : history.entrySet() ) {
+//					log.warn( item.getKey() + " -- " + item.getValue() );
+//				}
+                chart.addSeries(mode, history ) ;
+            }
+            chart.addMatsimLogo();
+            chart.saveAsPng(this.modeFileName + ".png", 800, 600);
+
+            /////// EDIT: STACKED_BAR ///////////////////////////////////////////////////////
+            if (event.getIteration() > this.minIteration) {
+                // create chart when data of more than one iteration is available.
+                StackedBarChart chart2 = new StackedBarChart("Mode Statistics", "iteration", "share");
+                for (Entry<String, Map<Integer, Double>> entry : this.modeHistories.entrySet()) {
+                    String mode = entry.getKey();
+                    Map<Integer, Double> history = entry.getValue();
+                    double[] historyArray = new double[history.size()];
+                    int i = 0;
+                    for ( Entry<Integer,Double> entryHistory : history.entrySet() ) {
+                        historyArray[i] = entryHistory.getValue();
+                        i++;
+                    }
+                    chart2.addSeries(mode, historyArray);
+                }
+                chart2.addMatsimLogo();
+                chart2.saveAsPng(this.modeFileName + "_stackedbar.png", 800, 600);
+            }
+        }
+        modeCnt.clear();
+    }
+
+    public final Map<String, Map<Integer, Double>> getModeHistories() {
+        return Collections.unmodifiableMap( this.modeHistories ) ;
+    }
+
+    ////////////copied methods - to not depend on dvrp ///////////////////////////////////////////////////////
+    private void makeStayTaskSeriesGrey(XYPlot plot) {
+        XYDataset dataset = plot.getDataset(0);
+        for (int i = 0; i < dataset.getSeriesCount(); i++) {
+            plot.getRenderer().setSeriesPaint(i, Color.LIGHT_GRAY);
+            return;
+        }
+    }
+    private static void saveAsPNG(JFreeChart chart, String filename, int width, int height) {
+        try {
+            ChartUtils.writeChartAsPNG(new FileOutputStream(filename + ".png"), chart, width, height);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////
+}

--- a/src/main/java/org/matsim/run/CarfreeMultimodalLinkChooser.java
+++ b/src/main/java/org/matsim/run/CarfreeMultimodalLinkChooser.java
@@ -1,0 +1,37 @@
+package org.matsim.run;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.MultimodalLinkChooser;
+import org.matsim.facilities.Facility;
+
+/**
+ * @author Simon Meinhardt (simei94)
+ */
+
+public class CarfreeMultimodalLinkChooser implements MultimodalLinkChooser {
+
+    @Override
+    public Link decideOnLink(Facility facility, Network network) {
+
+        Id<Link> originalLinkId = null ;
+
+        try {
+            originalLinkId = facility.getLinkId() ;
+        } catch ( Exception ee ) {
+            // there are implementations that throw an exception here although "null" is, in fact, an interpretable value. kai, oct'18
+        }
+
+        if(facility.getCoord() == null) {
+            throw new RuntimeException("link for facility cannot be determined when neither facility link id nor facility coordinate given") ;
+        }
+
+        //This basically is the only difference to MultiModalLinkChooserDefaultImpl as here we are saying that we do not care about the originally
+        //assigned link, we just assign it again. For most scenarios with filtered networks car = ride = bike e.g. it should always be originalLinkId = modefilteredLink.getId() -sm0622
+        Link modeFilteredLink = NetworkUtils.getNearestLink(network, facility.getCoord());
+
+        return modeFilteredLink;
+    }
+}

--- a/src/main/java/org/matsim/run/RunLeipzigScenario.java
+++ b/src/main/java/org/matsim/run/RunLeipzigScenario.java
@@ -9,6 +9,7 @@ import ch.sbb.matsim.routing.pt.raptor.RaptorIntermodalAccessEgress;
 import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.matsim.analysis.LeipzigModeStatsControlerListener;
 import org.matsim.analysis.ModeChoiceCoverageControlerListener;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
@@ -50,6 +51,7 @@ import org.matsim.core.replanning.choosers.ForceInnovationStrategyChooser;
 import org.matsim.core.replanning.choosers.StrategyChooser;
 import org.matsim.core.replanning.strategies.DefaultPlanStrategiesModule;
 import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.router.MultimodalLinkChooser;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorConfigGroup;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsConfigGroup;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsModule;
@@ -83,6 +85,9 @@ public class RunLeipzigScenario extends MATSimApplication {
 
 	@CommandLine.Option(names = "--with-drt", defaultValue = "false", description = "Enable DRT service")
 	private boolean drt;
+
+	@CommandLine.Option(names = "--carfreeArea", defaultValue = "false", description = "enable simulation of carfree area")
+	private boolean carfreeArea;
 
 	@CommandLine.Option(names = "--with-bikes", defaultValue = "false", description = "Enable qsim for bikes", negatable = true)
 	private boolean bike;
@@ -211,6 +216,11 @@ public class RunLeipzigScenario extends MATSimApplication {
 
 				bind(AnalysisMainModeIdentifier.class).to(LeipzigMainModeIdentifier.class);
 				addControlerListenerBinding().to(ModeChoiceCoverageControlerListener.class);
+
+				if(carfreeArea) {
+					addControlerListenerBinding().to(LeipzigModeStatsControlerListener.class);
+					bind(MultimodalLinkChooser.class).to(CarfreeMultimodalLinkChooser.class);
+				}
 
 				addControlerListenerBinding().to(StrategyWeightFadeout.class).in(Singleton.class);
 

--- a/src/main/java/org/matsim/run/prepare/PrepareNetworkCarFree.java
+++ b/src/main/java/org/matsim/run/prepare/PrepareNetworkCarFree.java
@@ -1,0 +1,84 @@
+package org.matsim.run.prepare;
+
+import com.google.common.collect.Sets;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.application.MATSimAppCommand;
+import org.matsim.application.options.ShpOptions;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.MultimodalNetworkCleaner;
+import org.matsim.core.utils.geometry.geotools.MGC;
+import org.opengis.feature.simple.SimpleFeature;
+import picocli.CommandLine;
+
+import java.util.*;
+
+@CommandLine.Command(
+        name = "network",
+        description = "Adapt network to one or more car-free zones. Therefore a shape file of the wished car-free area is needed. "
+)
+
+public class PrepareNetworkCarFree implements MATSimAppCommand {
+
+    @CommandLine.Option(names = "--network", description = "Path to network file", required = true)
+    private String networkFile;
+
+    @CommandLine.Mixin()
+    private ShpOptions shp = new ShpOptions();
+
+    @CommandLine.Option(names = "--output", description = "Output path of the prepared network", required = true)
+    private String outputPath;
+
+    @CommandLine.Option(names = "--modes", description = "List of modes to remove", required = true, defaultValue = TransportMode.car)
+    private String modes;
+
+    public static void main(String[] args) {
+        new PrepareNetworkCarFree().execute(args);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        Network network = NetworkUtils.readNetwork(networkFile);
+        Geometry carFreeArea = null;
+        List<SimpleFeature> features = shp.readFeatures();
+        for (SimpleFeature feature : features) {
+            if (carFreeArea == null) {
+                carFreeArea = (Geometry) feature.getDefaultGeometry();
+            } else {
+                carFreeArea = carFreeArea.union((Geometry) feature.getDefaultGeometry());
+            }
+        }
+
+        String[] modesToRemove = modes.split(",");
+
+        for (Link link : network.getLinks().values()) {
+
+            if (!link.getAllowedModes().contains("car")){
+                continue;
+            }
+
+            boolean isInsideCarFreeZone = MGC.coord2Point(link.getFromNode().getCoord()).within(carFreeArea) ||
+                    MGC.coord2Point(link.getToNode().getCoord()).within(carFreeArea);
+
+            if (isInsideCarFreeZone) {
+                Set<String> allowedModes = new HashSet<>(link.getAllowedModes());
+
+                for( String mode : modesToRemove) {
+                    allowedModes.remove(mode);
+                }
+                link.setAllowedModes(allowedModes);
+            }
+        }
+        MultimodalNetworkCleaner multimodalNetworkCleaner = new MultimodalNetworkCleaner(network);
+        multimodalNetworkCleaner.run(Sets.newHashSet(modesToRemove));
+
+
+        NetworkUtils.writeNetwork(network, outputPath);
+        System.out.println("Network including a car-free area has been written to " + outputPath);
+
+        return 0;
+    }
+
+}

--- a/src/test/java/org/matsim/run/CarfreeMultimodalLinkChooserTest.java
+++ b/src/test/java/org/matsim/run/CarfreeMultimodalLinkChooserTest.java
@@ -1,0 +1,102 @@
+package org.matsim.run;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
+import org.matsim.core.router.MultimodalLinkChooser;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.facilities.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Simon Meinhardt (simei94)
+ */
+
+class CarfreeMultiModalLinkChooserTest {
+
+    @Test
+    public void testLinkChooserMultimodalNetwork() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        Set<String> modes = new HashSet<>();
+        modes.add(TransportMode.car);
+        modes.add(TransportMode.bike);
+
+        Network network = createAndAddNetwork(scenario, modes);
+        Link carLink = network.getLinks().get(Id.createLinkId("1_" + TransportMode.car));
+
+        ActivityFacilitiesFactory fac = new ActivityFacilitiesFactoryImpl();
+        ActivityFacility facility = fac.createActivityFacility(Id.create("fac1", ActivityFacility.class), new Coord((double) 0, (double) 0),
+                carLink.getId());
+
+        TransportModeNetworkFilter filter = new TransportModeNetworkFilter(network);
+        Network bikeOnlyNetwork = NetworkUtils.createNetwork();
+        Set<String> modesToFilter = new HashSet<>();
+        modesToFilter.add(TransportMode.bike);
+        filter.filter(bikeOnlyNetwork, modesToFilter);
+
+        MultimodalLinkChooser linkChooser = new CarfreeMultimodalLinkChooser();
+        Link bikeLink = linkChooser.decideOnLink(facility, bikeOnlyNetwork);
+
+        Assert.assertFalse(carLink.getId() == bikeLink.getId());
+    }
+
+    @Test
+    public void testLinkChooserSinglemodalNetwork() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        Set<String> modes = new HashSet<>();
+        modes.add(TransportMode.car);
+        modes.add(TransportMode.bike);
+
+        Network network = createAndAddNetwork(scenario, modes);
+        Link carLink = network.getLinks().get(Id.createLinkId("1_" + TransportMode.car));
+
+        ActivityFacilitiesFactory fac = new ActivityFacilitiesFactoryImpl();
+        ActivityFacility facility = fac.createActivityFacility(Id.create("fac1", ActivityFacility.class), new Coord((double) 0, (double) 0),
+                carLink.getId());
+
+        TransportModeNetworkFilter filter = new TransportModeNetworkFilter(network);
+        Network carOnlyNetwork = NetworkUtils.createNetwork();
+        Set<String> modesToFilter = new HashSet<>();
+        modesToFilter.add(TransportMode.car);
+        filter.filter(carOnlyNetwork, modesToFilter);
+
+        MultimodalLinkChooser linkChooser = new CarfreeMultimodalLinkChooser();
+        Link sameLink = linkChooser.decideOnLink(facility, carOnlyNetwork);
+
+        Assert.assertTrue(carLink.getId() == sameLink.getId());
+    }
+
+    private Network createAndAddNetwork(Scenario sc, Set<String> modes) {
+        Network net = sc.getNetwork();
+        Link l1;
+        {
+            NetworkFactory nf = net.getFactory();
+            Set<String> allowedModes = new HashSet<>();
+            Node n1 = nf.createNode(Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+            Node n2 = nf.createNode(Id.create("2", Node.class), new Coord((double) 1000, (double) 0));
+            net.addNode(n1);
+            net.addNode(n2);
+
+            for(String mode : modes) {
+                l1 = nf.createLink(Id.createLinkId("1_" + mode), n1, n2);
+                allowedModes.add(mode);
+                l1.setAllowedModes(allowedModes);
+                net.addLink(l1);
+                allowedModes.clear();
+            }
+        }
+        return net;
+    }
+}


### PR DESCRIPTION
To simulate the impact of carfree areas within the city the CarfreeMultimodalLinkChooser is introduced. It allows us to basically keep bike + other wished transport modes inside of the carfree zones, while cars e.g. cannot go there anymore. Some more analysis classes and useful infrastructure such as a carfree network creator are added as well.